### PR TITLE
Changed 'master' to 'main' branch for cmark.

### DIFF
--- a/utils/baremetal/update-checkout-config.json
+++ b/utils/baremetal/update-checkout-config.json
@@ -57,7 +57,7 @@
                 "compiler-rt": "swift-5.1-branch",
                 "swift": "embedded-5.1",
                 "lldb": "swift-5.1-branch",
-                "cmark": "master",
+                "cmark": "main",
                 "llbuild": "swift-5.1-branch",
                 "swiftpm": "embedded-5.1",
                 "swift-syntax": "swift-5.1-branch",


### PR DESCRIPTION
Many GitHub repos now follow the new branch naming.
The 'master' branch couldn't be found and the update-checkout script failed.